### PR TITLE
fix BlobBuilder undefined bug on Safari

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -909,7 +909,7 @@
 		};
 	}
 
-	if (typeof BlobBuilder == "undefined" && typeof Blob == "function") {
+	if (typeof BlobBuilder == "undefined" && typeof Blob == "object") {
 		BlobBuilder = function() {
 			var that = this, blobParts = [ new Blob() ];
 			that.append = function(data) {


### PR DESCRIPTION
thx, ur change is working when I modify a little bit

`typeof Blob == "function"` --> `typeof Blob == "object"`

maybe only for Safari 6, had no test on <6
