### PR TITLE
Case-insentivity for MIME-type mapping 

### DIFF
--- a/WebContent/mime-types.js
+++ b/WebContent/mime-types.js
@@ -995,7 +995,7 @@
 
 	zip.getMimeType = function(filename) {
 		var defaultValue = "application/octet-stream";
-		return filename ? mimeTypes[filename.split(".").pop()] || defaultValue : defaultValue;
+		return filename && mimeTypes[filename.split(".").pop().toLowerCase()] || defaultValue;
 	};
 
 })();


### PR DESCRIPTION
A small fix for a case-insensitive `zip.getMimeType` method.
