### PR TITLE
Fixes dependency issues between these libs

### DIFF
--- a/WebContent/mime-types.js
+++ b/WebContent/mime-types.js
@@ -26,7 +26,7 @@
  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-(function() {
+(function(obj) {
 	var table = {
 		"application" : {
 			"andrew-inset" : "ez",
@@ -993,9 +993,12 @@
 		return mimeTypes;
 	})();
 
-	zip.getMimeType = function(filename) {
+	if (!obj.zip)
+		obj.zip = {};
+
+	obj.zip.getMimeType = function(filename) {
 		var defaultValue = "application/octet-stream";
 		return filename && mimeTypes[filename.split(".").pop().toLowerCase()] || defaultValue;
 	};
 
-})();
+})(this);

--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -775,27 +775,28 @@
 		};
 	}
 
-	obj.zip = {
-		Reader : Reader,
-		Writer : Writer,
-		BlobReader : BlobReader,
-		Data64URIReader : Data64URIReader,
-		TextReader : TextReader,
-		BlobWriter : BlobWriter,
-		Data64URIWriter : Data64URIWriter,
-		TextWriter : TextWriter,
-		createReader : function(reader, callback, onerror) {
-			reader.init(function() {
-				callback(createZipReader(reader, onerror));
-			}, onerror);
-		},
-		createWriter : function(writer, callback, onerror, dontDeflate) {
-			writer.init(function() {
-				callback(createZipWriter(writer, onerror, dontDeflate));
-			}, onerror);
-		},
-		workerScriptsPath : "",
-		useWebWorkers : true
+	if (!obj.zip)
+		obj.zip = {};
+
+	obj.zip.Reader = Reader;
+	obj.zip.Writer = Writer;
+	obj.zip.BlobReader = BlobReader;
+	obj.zip.Data64URIReader = Data64URIReader;
+	obj.zip.TextReader = TextReader;
+	obj.zip.BlobWriter = BlobWriter;
+	obj.zip.Data64URIWriter = Data64URIWriter;
+	obj.zip.TextWriter = TextWriter;
+	obj.zip.createReader = function(reader, callback, onerror) {
+		reader.init(function() {
+			callback(createZipReader(reader, onerror));
+		}, onerror);
 	};
+	obj.zip.createWriter = function(writer, callback, onerror, dontDeflate) {
+		writer.init(function() {
+			callback(createZipWriter(writer, onerror, dontDeflate));
+		}, onerror);
+	};
+	obj.zip.workerScriptsPath = "";
+	obj.zip.useWebWorkers = true;
 
 })(this);


### PR DESCRIPTION
When used in a browser, the order of download is unpredictable without a
module loader. Because both files manipulate and depend on the 'zip'
global they must behave appropriately.
