### PR TITLE
Added ability to add XHR progress listeners to HttpReader.

### DIFF
--- a/WebContent/tests/test-xhr-on-progress.html
+++ b/WebContent/tests/test-xhr-on-progress.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Demo XHR progress</title>
+
+<style>
+body {
+    font-family: Tahoma;
+    font-szie: 9pt;
+}
+div.tabs > span {
+    padding:0;
+    padding-right:0.5em;
+    margin:0;
+}
+textarea.content {
+    width: 100%;
+    height: 100%;
+    font-size: 9pt;
+}
+</style>
+
+</head>
+<body>
+
+<script src="http://code.jquery.com/jquery-1.9.1.js"></script>
+<script src="../zip.js"></script>
+<script src="../zip-ext.js"></script>
+<script>
+zip.workerScriptsPath = "../";
+</script>
+<script src="test-xhr-on-progress.js"></script>
+<script>
+$(function () {
+    testXhrOnProgress.setupUi($("#testDiv"), "/dojo/dojo-release-1.8.3-src.zip");
+});
+</script>
+
+<div id="testDiv">
+
+<p><button>Download</button> <input id="downloadUrl" size="64"> <span id="downloadProgress"></span></p>
+
+<div id="tabs" class="tabs"></div>
+<div id="entryName"></div>
+<div style="height: 600px;">
+<textarea id="content" class="content"></textarea>
+</div>
+
+</div>
+
+</body>

--- a/WebContent/tests/test-xhr-on-progress.js
+++ b/WebContent/tests/test-xhr-on-progress.js
@@ -1,0 +1,129 @@
+var testXhrOnProgress = (function () {
+
+    /**
+     * opts:
+     *  maxEntries - Limit the number of entries passed to onEntryData.
+     *  onEntryData - Callback for entry data. Args [entry, data].
+     *  progressListener - Callback for XHR progress. Args [evt], where evt is defined here "http://www.w3.org/TR/progress-events/#interface-progressevent".
+     */
+
+    function download(url, opts) {
+        opts = opts || {};
+        opts.maxEntries = +opts.maxEntries;
+
+        var httpReader = new zip.HttpReader(url);
+
+        if ("function" === typeof opts.progressListener) {
+            httpReader.addProgressListener(opts.progressListener);
+        }
+
+        function handleEntries(entries) {
+            var count = 0;
+            entries.forEach(function (entry) {
+                if (entry.directory || count >= opts.maxEntries) {
+                    return;
+                }
+                count++;
+                // get entry content as text
+                entry.getData(new zip.TextWriter("UTF-8"), function (data) {
+                    opts.onEntryData(entry, data);
+                }, function (current, total) {
+                    // onprogress callback
+                    //console.log("onprogress", entry.filename, current, " of ", total);
+                });
+            });
+        }
+
+        // use a BlobReader to read the zip from a Blob object
+        zip.createReader(httpReader, function (reader) {
+            try {
+                // get all entries from the zip
+                reader.getEntries(handleEntries);
+            } finally {
+                // close the zip reader
+                reader.close(function () {
+                    //onclose callback
+                    console.log("closed");
+                });
+            }
+        }, function (error) {
+            // onerror callback
+            console.log("error", error);
+        });
+    }
+
+    function setupUi(parentEl, url) {
+        var entryContents = window["entryContents"] = {};
+
+        function createOpts() {
+            var opts = {};
+
+            opts.maxEntries = 20;
+
+            opts.onEntryData = function (entry, data) {
+                console.log(entry.filename, entry.lastModDate);
+                entryContents[entry.filename] = data;
+                addTab(entry.filename);
+            };
+
+            opts.progressListener = (function () {
+                // report after each 10%
+                var reportingThreshold = 0.1;
+                var nextReportAt = 0;
+                return function (evt) {
+                    if (evt.lengthComputable) {
+                        var percentComplete = evt.loaded / evt.total;
+                        if (percentComplete < nextReportAt) {
+                            return;
+                        }
+                        console.log(evt, percentComplete);
+
+                        // update the new report value
+                        nextReportAt = Math.min(1.0, nextReportAt + reportingThreshold);
+
+                        var str = "" + (percentComplete * 100);
+                        str = str.substring(0, 5) + "%";
+                        parentEl.find("#downloadProgress").html(str);
+                    }
+                };
+            }());
+
+            return opts;
+        }
+
+        function addTab(name) {
+            var displayName = name;
+            var idx = displayName.lastIndexOf("/");
+            if (idx > -1) {
+                displayName = displayName.substring(idx + 1);
+            }
+            var tab = $("<span>").attr("data-content-id", name);
+            var a = $("<a>").html(displayName).attr("href", "#");
+            tab.append(a);
+            parentEl.find("#tabs").append(tab).append(" ");
+        }
+
+        parentEl.find("button").click(function () {
+            // init
+            entryContents = window["entryContents"] = {};
+
+            var url = $("#downloadUrl").val();
+            download(url, createOpts());
+        });
+
+        parentEl.find("#tabs").on("click", "a", function (evt) {
+            evt.stopPropagation();
+            var id = $(evt.target).closest("[data-content-id]").attr("data-content-id");
+            console.log(evt, id);
+            parentEl.find("#entryName").html(id);
+            parentEl.find("#content").val(entryContents[id]);
+        });
+
+        parentEl.find("#downloadUrl").val(url);
+    }
+
+    return {
+        setupUi: setupUi
+    };
+
+}());

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -55,6 +55,9 @@
 					callback();
 				}, false);
 				request.addEventListener("error", onerror, false);
+				that.progressListeners.forEach(function (listener) {
+					request.addEventListener("progress", listener, false);
+				});
 				request.open("GET", url);
 				request.responseType = "arraybuffer";
 				request.send();
@@ -82,9 +85,13 @@
 		that.size = 0;
 		that.init = init;
 		that.readUint8Array = readUint8Array;
+		that.progressListeners = [];
 	}
 	HttpReader.prototype = new Reader();
 	HttpReader.prototype.constructor = HttpReader;
+	HttpReader.prototype.addProgressListener = function(listener) {
+		this.progressListeners.push(listener);
+	};
 
 	function HttpRangeReader(url) {
 		var that = this;


### PR DESCRIPTION
Hi,

Firstly, thanks for creating this library.

I was playing about a bit trying to download large zips, and I thought it would be a good idea to be able to get progress updates from the HttpReader.  So I added this.

For the test provided I was downloading a local copy of "dojo-release-1.8.3-src.zip", which is a 38Mb zip.  It took 3 or 4 seconds to download, even from localhost - hence wanting to see progress updates.

Maybe you'd like to pull this in, or create something equivalent.

Thanks.
