### PR TITLE
Retrieving entry content in firefox never raises the success event.

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -214,7 +214,11 @@
 				callback(e.target.result);
 			};
 			reader.onerror = onerror;
-			reader.readAsText(blob, encoding);
+			if (encoding) {
+				reader.readAsText(blob, encoding);
+			} else {
+				reader.readAsText(blob);
+			}
 		}
 
 		that.init = init;


### PR DESCRIPTION
Hello,

When using the zip filesystem in FireFox I had troubles to retrieve entrie's contents, it might be a problem in the browser itself, but is not documented how the browser should be behave. The problem lies in calling the readAsText method in the FileReader object, so I added a very simple verification to avoid such error.

Thanks
Alexei