### PR TITLE
Don't throw unhandled exception when EOCDR is not found

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -573,6 +573,11 @@
 		};
 
 		function seekEOCDR(offset, entriesCallback) {
+			if (reader.size <= offset) {
+				onerror(ERR_BAD_FORMAT);
+				return;
+			}
+
 			reader.readUint8Array(reader.size - offset, offset, function(bytes) {
 				var dataView = getDataHelper(bytes.length, bytes).view;
 				if (dataView.getUint32(0) != 0x504b0506) {


### PR DESCRIPTION
On Chrome I get a `Uncaught Error: IndexSizeError: DOM Exception 1` when attempting to read a file with random data as a zip file. This error happens in the `onload` callback of FileReader so it remains uncaught. This pull requests improves the error handling.

Possibly related to https://github.com/gildas-lormeau/zip.js/issues/74
