### PR TITLE
Workaround to prevent caching of byte range requests in Safari

### DIFF
--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -108,6 +108,7 @@
 			request.open("GET", url);
 			request.responseType = "arraybuffer";
 			request.setRequestHeader("Range", "bytes=" + index + "-" + (index + length - 1));
+			request.setRequestHeader("If-None-Match", "webkit-no-cache");
 			request.addEventListener("load", function() {
 				callback(request.response);
 			}, false);


### PR DESCRIPTION
Bug in webkit described here:
https://bugs.webkit.org/show_bug.cgi?id=82672

Adding the If-None-Match header with a fake eTag resolves caching issue.
