### PR TITLE
Fix native codecs

### DIFF
--- a/WebContent/deflate.js
+++ b/WebContent/deflate.js
@@ -2013,7 +2013,7 @@
 				z.avail_out = bufsize;
 				err = z.deflate(flush);
 				if (err != Z_OK)
-					throw "deflating: " + z.msg;
+					throw new Error("deflating: " + z.msg);
 				if (z.next_out_index)
 					if (z.next_out_index == bufsize)
 						buffers.push(new Uint8Array(buf));
@@ -2039,7 +2039,7 @@
 				z.avail_out = bufsize;
 				err = z.deflate(Z_FINISH);
 				if (err != Z_STREAM_END && err != Z_OK)
-					throw "deflating: " + z.msg;
+					throw new Error("deflating: " + z.msg);
 				if (bufsize - z.avail_out > 0)
 					buffers.push(new Uint8Array(buf.subarray(0, z.next_out_index)));
 				bufferSize += z.next_out_index;

--- a/WebContent/inflate.js
+++ b/WebContent/inflate.js
@@ -2121,11 +2121,11 @@
 				err = z.inflate(flush);
 				if (nomoreinput && (err == Z_BUF_ERROR)) {
 					if (z.avail_in != 0)
-						return -1;
+						throw new Error("inflating: bad input");
 				} else if (err != Z_OK && err != Z_STREAM_END)
-					throw "inflating: " + z.msg;
+					throw new Error("inflating: " + z.msg);
 				if ((nomoreinput || err == Z_STREAM_END) && (z.avail_in == data.length))
-					return -1;
+					throw new Error("inflating: bad input");
 				if (z.next_out_index)
 					if (z.next_out_index == bufsize)
 						buffers.push(new Uint8Array(buf));


### PR DESCRIPTION
Fix inflate.js error handling, according to nahidakbar in issue #101
inflate|deflate.js: report error by throwing Error.
