### PR TITLE
Missing obj.zip.workerScriptsPath to load workers

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -855,7 +855,7 @@
 	}
 
 	function createWorker(scripts, callback, onerror) {
-		var worker = new Worker(scripts[0]);
+		var worker = new Worker(obj.zip.workerScriptsPath + scripts[0]);
 		// record total consumed time by inflater/deflater/crc32 in this worker
 		worker.codecTime = worker.crcTime = 0;
 		worker.postMessage({ type: 'importScripts', scripts: scripts.slice(1) });


### PR DESCRIPTION
When using zip.js in a nested folder using obj.zip.workerScriptsPath has no effect, and "z-worker.js" is triggering a 404 error.
