### PR TITLE
Resolve URLs relative to base / workerScriptsPath

### DIFF
--- a/WebContent/tests/config.js
+++ b/WebContent/tests/config.js
@@ -2,16 +2,17 @@
 
 zip.useWebWorkers = true;
 
+zip.workerScriptsPath = '..';
 zip.workerScripts = {
 	// default zip.js implementation
-	deflater: ['deflate.js'],
-	inflater: ['inflate.js'],
+	deflater: ['z-worker.js', 'deflate.js'],
+	inflater: ['z-worker.js', 'inflate.js'],
 
 	// zlib-asm
-	// deflater: ['zlib-asm/zlib.js', 'zlib-asm/codecs.js'],
-	// inflater: ['zlib-asm/zlib.js', 'zlib-asm/codecs.js'],
+	// deflater: ['z-worker.js', 'zlib-asm/zlib.js', 'zlib-asm/codecs.js'],
+	// inflater: ['z-worker.js', 'zlib-asm/zlib.js', 'zlib-asm/codecs.js'],
 
 	// pako
-	// deflater: ['pako/pako.min.js', 'pako/codecs.js'],
-	// inflater: ['pako/pako.min.js', 'pako/codecs.js'],
+	// deflater: ['z-worker.js', 'pako/pako.min.js', 'pako/codecs.js'],
+	// inflater: ['z-worker.js', 'pako/pako.min.js', 'pako/codecs.js'],
 };


### PR DESCRIPTION
- Move hard-coded z-worker.js out of config.
- Resolve workerScriptsPath relative to page URL.
- Resolve relative worker URLs relative to workerScriptsPath.
