### PR TITLE
Added inital Support for ES6 Promises

### DIFF
--- a/WebContent/zip-promise.js
+++ b/WebContent/zip-promise.js
@@ -1,0 +1,84 @@
+/*
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in
+ the documentation and/or other materials provided with the distribution.
+
+ 3. The names of the authors may not be used to endorse or promote products
+ derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT,
+ INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Wraps the createWriter method into a Promise based Wrapper
+ */
+zip.createPromiseWriter = function(writer, dontDeflate) {
+	"use strict";
+	
+	return new Promise(function(resolve, reject) {
+		zip.createWriter(writer, function(writer) {
+			// The method of the original writer (add and close) get their Promise Based version
+			resolve({add: function(name, reader, onprogress, options) {
+				return new Promise(function(resolve) {
+					writer.add(name, reader, resolve, onprogress, options);
+				});
+			},
+			close: function() {
+				return new Promise(function(resolve) {
+					writer.close(resolve);
+				});
+			}});
+		}, reject, dontDeflate);
+	});
+};
+
+/*
+ * Wraps the createReader method into a Promise based Wrapper
+ */
+zip.createPromiseReader = function(reader) {
+	"use strict";
+	
+	return new Promise(function(resolve, reject) {
+		zip.createReader(reader, function (reader) {
+			// The reader functions (getEntries and close) need their Promise based version
+			resolve({getEntries: function() {
+				return new Promise(function(resolve) {
+					reader.getEntries(function(entries) {
+						resolve(entries.map(function(entry) {
+							// save the old getData function and overwrite with a Promise based function
+							var getData = entry.getData;
+							entry.getData = function (writer, onprogress, checkCrc32) {
+								return new Promise(function (resolve) {
+									// use call to get this in the function right 
+									getData.call(entry, writer, resolve, onprogress, checkCrc32);
+								});
+							};
+							return entry;
+						}));
+					});
+				});
+			}, 
+			close: function() {
+				return new Promise(function(resolve) {
+					reader.close(resolve);
+				});
+			}});
+		}, reject);
+	});
+};


### PR DESCRIPTION
This adds inital support for the EcmaScript 6 Promises to the zip.js external API. A good instruction is given at [HTML5Rocks: JavaScript Promises](http://www.html5rocks.com/en/tutorials/es6/promises/). With this it is possible to Write a zip and unzip function like this:

``` javascript
var files = [{name: "a.txt", content: "Test"},
    {name: "b.txt", content: "Test2"},
    {name: "c.txt", content: "Test3"}]
zipBlob(files, function(zippedBlob) {
  // unzip the data stored in zippedBlob
  unzipBlob(zippedBlob, function(unzippedBlob) {
      console.log(unzippedBlob) // ["Test", "Test2", "Test3"]
  });
});

function zipBlob(files, callback) {
  // use a zip.BlobWriter object to write zipped data into a Blob object
  zip.createWriter(new zip.BlobWriter("application/zip")).then(function(zipWriter) {
    // add one file after another
      files.reduce(function (sequence, file) {
          var blob = new Blob([ file.content ], {
              type : "text/plain"
          });
          return sequence.then(function () {
              return zipWriter.add(file.name, new zip.BlobReader(blob));
          })
      }, Promise.resolve()).then(function () {
          // close the writer after all files zipped
          zipWriter.close(callback);
        });
  });
}

function unzipBlob(blob, callback) {
  // use a zip.BlobReader object to read zipped data stored into blob variable
  zip.createReader(new zip.BlobReader(blob)).then(function(zipReader) {
    // get entries from the zip file
    zipReader.getEntries().then(function(entries) {
        Promise.all(entries.map(function(entry) {
            return entry.getData(new zip.TextWriter());
        })).then(function(d) {
            zipReader.close();
            callback(d);
        })
    });
  });
}

function onerror(message) {
  console.error(message);
}
```

ES6 Promises Browser support can be check at http://kangax.github.io/compat-table/es6/#Promise

In development I tried to:
- Not change the existing API or the need to adjust any existing code that uses the API
- Do not change the behavior if the Browser does not support Promises
- Call the callback first and resolve the Promise afterwards
- Make the change as small as possible

I have not tested this yet in a Browser without Promise support (IE). If this is interesting I think is good to add  support to the polyfill from https://github.com/jakearchibald/es6-promise#readme
