### PR TITLE
Added an IndexedDB backend called DBWriter.

### DIFF
--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -256,7 +256,7 @@
 		}
 
 		function close() {
-			blobs = [];
+			blobs = null;
 			window.removeEventListener("storage", pongDB);
 			window.removeEventListener("unload", pongDB);
 			indexedDB.deleteDatabase(dbName + "_" + instance);

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -258,7 +258,7 @@
 		}
 
 		function broadcastPingDB() {
-			localStorage.zipjs = Date.now();
+			sessionStorage.zipjs = Date.now();
 		}
 
 		function pongDB(event) {

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -241,6 +241,7 @@
 		function addInstanceDB(callback, onerror) {
 			var request;
 			try {
+				// The temporary option is only supported in Firefox 26+.
 				request = indexedDB.open(dbName + "_" + instance, {temporary: true});
 			} catch (e) {
 				request = indexedDB.open(dbName + "_" + instance);

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -278,9 +278,16 @@
 		function cleanUpOldInstances() {
 			broadcastPingDB();
 			pongDB();
+			// This gives all other tabs 2 seconds to respond to a ping, which
+			// should be enough time, as the event loop for inactive tabs
+			// could run as infrequently as once per second. The second second
+			// is to allow for a bit of wiggle room if the CPU is loaded.
+			// Then, we're going to delete the blobs for instances that responded
+			// less then 3 seconds ago, with the extra second for wiggle room
+			// again.
 			setTimeout(function () {
-				findOldInstances(10000);
-			}, 5000);
+				findOldInstances(3000);
+			}, 2000);
 		}
 
 		function findOldInstances(maxAge) {

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -212,7 +212,7 @@
 		var db, tempDB, that = this, blobs, dbName = "zipjs", instance;
 
 		function init(callback, onerror) {
-			var request = indexedDB.open(dbName, 5);
+			var request = indexedDB.open(dbName);
 			request.onerror = onerror;
 			request.onupgradeneeded = function (event) {
 				db = event.target.result;

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -268,7 +268,11 @@
 		}
 
 		function pongDB(event) {
-			if ((event !== undefined && event.key === "zipjs") && instance) {
+			// If this is not called as an event handler, or if the event
+			// was trigger by another instance of this object and this
+			// object is active, then update this instance's updated time
+			// in the instance database.
+			if ((event !== undefined || event.key === "zipjs") && instance) {
 				db.transaction(["instances"], "readwrite")
 					.objectStore("instances")
 					.put(Date.now(), instance);

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -208,7 +208,7 @@
 	FileWriter.prototype = new Writer();
 	FileWriter.prototype.constructor = FileWriter;
 
-	function DBWriter(contentType) {
+	function DBBackedBlobWriter(contentType) {
 		var instancesDB, instanceFilesDB, that = this, blobs, dbName = "zipjs", instance;
 
 		function init(callback, onerror) {
@@ -379,7 +379,7 @@
 	zip.HttpRangeReader = HttpRangeReader;
 	zip.ArrayBufferReader = ArrayBufferReader;
 	zip.ArrayBufferWriter = ArrayBufferWriter;
-	zip.DBWriter = DBWriter;
+	zip.DBBackedBlobWriter = DBBackedBlobWriter;
 
 	if (zip.fs) {
 		ZipDirectoryEntry = zip.fs.ZipDirectoryEntry;

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -259,7 +259,7 @@
 		function close() {
 			blobs = null;
 			window.removeEventListener("storage", respondToPing);
-			window.removeEventListener("unload", respondToPing);
+			window.removeEventListener("unload", close);
 			indexedDB.deleteDatabase(dbName + "_" + instance);
 		}
 

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -257,9 +257,9 @@
 
 		function close() {
 			blobs = [];
-			indexedDB.deleteDatabase(dbName + "_" + instance);
 			window.removeEventListener("storage", pongDB);
 			window.removeEventListener("unload", pongDB);
+			indexedDB.deleteDatabase(dbName + "_" + instance);
 		}
 
 		function broadcastPingDB() {

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -239,7 +239,12 @@
 		}
 
 		function addInstanceDB(callback, onerror) {
-			var request = indexedDB.open(dbName + "_" + instance);
+			var request;
+			try {
+				request = indexedDB.open(dbName + "_" + instance, {temporary: true});
+			} catch (e) {
+				request = indexedDB.open(dbName + "_" + instance);
+			}
 			request.onerror = onerror;
 			request.onupgradeneeded = function (event) {
 				tempDB = event.target.result;

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -371,8 +371,8 @@
 		that.getData = getData;
 		that.close = close;
 	}
-	DBWriter.prototype = new Writer();
-	DBWriter.prototype.constructor = FileWriter;
+	DBBackedBlobWriter.prototype = new Writer();
+	DBBackedBlobWriter.prototype.constructor = FileWriter;
 
 	zip.FileWriter = FileWriter;
 	zip.HttpReader = HttpReader;

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -333,6 +333,7 @@
 				request.onsuccess = function (event) {
 					getEntry(request.result);
 				};
+				request.onerror = onerror;
 			}
 
 			function getEntry(key) {
@@ -344,6 +345,7 @@
 				request.onsuccess = function (event) {
 					callback(request.result.data);
 				};
+				request.onerror = onerror;
 			}
 
 			putEntry(blob);

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -231,7 +231,6 @@
 			request.onerror = onerror;
 			request.onsuccess = function (event) {
 				instance = request.result;
-				console.log("Current instance " + instance);
 				cleanUpOldInstances();
 				window.addEventListener("storage", pongDB);
 				window.addEventListener("unload", close);
@@ -254,6 +253,8 @@
 		function close() {
 			blobs = [];
 			indexedDB.deleteDatabase(dbName + "_" + instance);
+			window.removeEventListener("storage", pongDB);
+			window.removeEventListener("unload", pongDB);
 		}
 
 		function broadcastPingDB() {
@@ -262,7 +263,6 @@
 
 		function pongDB(event) {
 			if ((event !== undefined && event.key === "zipjs") && instance) {
-				console.log("Pong from instance " + instance);
 				db.transaction(["instances"], "readwrite")
 								.objectStore("instances")
 								.put(Date.now(), instance);
@@ -311,9 +311,6 @@
 			function putEntry(blob) {
 				var t = tempDB.transaction(["files"], "readwrite"),
 					objectStore, request;
-				t.oncomplete = function () {
-					console.log("Make backed");
-				};
 				t.onerror = onerror;
 				objectStore = t.objectStore("files");
 				request = objectStore.put({instance: instance, data: blob});
@@ -354,6 +351,7 @@
 		that.init = init;
 		that.writeUint8Array = writeUint8Array;
 		that.getData = getData;
+		that.close = close;
 	}
 	DBWriter.prototype = new Writer();
 	DBWriter.prototype.constructor = FileWriter;

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -270,8 +270,8 @@
 		function pongDB(event) {
 			if ((event !== undefined && event.key === "zipjs") && instance) {
 				db.transaction(["instances"], "readwrite")
-								.objectStore("instances")
-								.put(Date.now(), instance);
+					.objectStore("instances")
+					.put(Date.now(), instance);
 			}
 		}
 

--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -263,16 +263,16 @@
 			indexedDB.deleteDatabase(dbName + "_" + instance);
 		}
 
-		function pingOtherInstances() {
+		function pingAllInstances() {
 			sessionStorage.zipjs = Date.now();
+			// That only triggers other tabs, not instances in this
+			// tab, so we need to trigger those manually.
+			var event = new StorageEvent("storage", {key: "zipjs"});
+			window.dispatchEvent(event);
 		}
 
 		function respondToPing(event) {
-			// If this is not called as an event handler, or if the event
-			// was trigger by another instance of this object and this
-			// object is active, then update this instance's updated time
-			// in the instance database.
-			if ((event !== undefined || event.key === "zipjs") && instance) {
+			if (event.key === "zipjs" && instance) {
 				instancesDB.transaction(["instances"], "readwrite")
 					.objectStore("instances")
 					.put(Date.now(), instance);
@@ -280,8 +280,7 @@
 		}
 
 		function cleanUpOldInstances() {
-			pingOtherInstances();
-			respondToPing();
+			pingAllInstances();
 			// This gives all other tabs 2 seconds to respond to a ping, which
 			// should be enough time, as the event loop for inactive tabs
 			// could run as infrequently as once per second. The second second


### PR DESCRIPTION
Since FileWriter didn't work in Firefox, but IndexedDB did, I figured that IndexedDB would be a good place to cache files for storage. It works just like the BlobWriter. In order to compensate for the lack of temporary storage in IndexedDB, the database is cleared on script load and window unload. However, it may leave data in the cache if the browser crashes.
