### PR TITLE
Fix #121: Add workaround for IE10

### DIFF
--- a/WebContent/z-worker.js
+++ b/WebContent/z-worker.js
@@ -94,7 +94,13 @@
 		}
 		if (!isAppend && (task.crcInput || task.crcOutput))
 			rmsg.crc = task.crc.get();
-		postMessage(rmsg, transferables);
+		
+		// posting a message with transferables will fail on IE10
+		try {
+			postMessage(rmsg, transferables);
+		} catch(ex) {
+			postMessage(rmsg); // retry without transferables
+		}
 	}
 
 	function onError(type, sn, e) {

--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -367,7 +367,13 @@
 					var msg = index === 0 ? initialMessage : {sn : sn};
 					msg.type = 'append';
 					msg.data = array;
-					worker.postMessage(msg, [array.buffer]);
+					
+					// posting a message with transferables will fail on IE10
+					try {
+						worker.postMessage(msg, [array.buffer]);
+					} catch(ex) {
+						worker.postMessage(msg); // retry without transferables
+					}
 					chunkIndex++;
 				}, onreaderror);
 			} else {


### PR DESCRIPTION
Fixes #121

Retry postMessage without transferables if exception is thrown.
[IE 10 Bug description](
https://connect.microsoft.com/IE/feedback/details/783468/ie10-window-postmessage-throws-datacloneerror-for-transferrable-arraybuffers)