### PR TITLE
Adds a new writer, ArrayBufferWriter which allows access to raw ArrayBuffer

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -202,6 +202,30 @@
 		callback(this.data);
 	};
 
+	function ArrayBufferWriter() {
+		var that = this;
+	    var ar;
+
+		function init(callback) {
+			callback();
+		}
+
+		function writeUint8Array(array, callback) {
+			ar = array;
+			callback();
+		}
+
+		function getData(callback, onerror) {
+			callback(ar);
+		}
+
+		that.init = init;
+		that.writeUint8Array = writeUint8Array;
+		that.getData = getData;
+	}
+	ArrayBufferWriter.prototype = new ArrayBufferWriter();
+	ArrayBufferWriter.prototype.constructor = ArrayBufferWriter;
+
 	function TextWriter(encoding) {
 		var that = this, blob;
 
@@ -927,6 +951,7 @@
 		BlobWriter : BlobWriter,
 		Data64URIWriter : Data64URIWriter,
 		TextWriter : TextWriter,
+		ArrayBufferWriter: ArrayBufferWriter,
 		createReader : function(reader, callback, onerror) {
 			onerror = onerror || onerror_default;
 

--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -204,19 +204,29 @@
 
 	function ArrayBufferWriter() {
 		var that = this;
-	    var ar;
+		var listOfArrays = [];
 
 		function init(callback) {
+		        listOfArrays = [];
 			callback();
 		}
 
 		function writeUint8Array(array, callback) {
-			ar = array;
+			listOfArrays.push(array);
 			callback();
 		}
 
 		function getData(callback, onerror) {
-			callback(ar);
+			var newLen = listOfArrays.reduce(function(prev, cur, index, arr) {
+				return prev + cur.byteLength;
+			},0);
+			var tmp = new Uint8Array(newLen);
+			var idx = 0;
+			listOfArray.map(function(cur,index,arr) {
+				tmp.set(new Uint8Array(cur),idx);
+				idx = idx + cur.byteLength;
+			});
+                        callback(tmp);
 		}
 
 		that.init = init;


### PR DESCRIPTION
in the process of needing to upload only some parts of a zip file, I needed to access the raw ArrayBuffer with the file contents.  Perhaps it wasn't clear that there was a better way to do this, but I created this small modification to allow easy access to the arraybuffer.

```
var writer = new zip.ArrayBufferWriter();
zipPart.getData(writer,function(arrayBuffer) {
     // use the arrayBuffer here
});
```
