### PR TITLE
Fix HttpReader when response has no content length

### DIFF
--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -51,7 +51,7 @@
 				request = new XMLHttpRequest();
 				request.addEventListener("load", function() {
 					if (!that.size)
-						that.size = Number(request.getResponseHeader("Content-Length"));
+						that.size = Number(request.getResponseHeader("Content-Length")) || Number(request.response.byteLength);
 					that.data = new Uint8Array(request.response);
 					callback();
 				}, false);
@@ -67,7 +67,12 @@
 			var request = new XMLHttpRequest();
 			request.addEventListener("load", function() {
 				that.size = Number(request.getResponseHeader("Content-Length"));
-				callback();
+				// If response header doesn't return size then prefetch the content.
+				if (!that.size) {
+					getData(callback, onerror);
+				} else {
+					callback();
+				}
 			}, false);
 			request.addEventListener("error", onerror, false);
 			request.open("HEAD", url);


### PR DESCRIPTION
Fixes a issue when using the HttpReader together with a zip writer. When the header request doesn't have a content-length then I found that it had to fetch all of the content otherwise the files would be corrupt in the final zip.

The use case is when zipping files from the local Filesystem with a url like this: "filesystem:http://domain.com/persistant/file.txt"