### PR TITLE
fix to read all the entries until no entries are returned

### DIFF
--- a/WebContent/tests/test20.html
+++ b/WebContent/tests/test20.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Demo readEntries()</title>
+</head>
+<body>
+	<script type="text/javascript" src="../zip.js"></script>
+	<script type="text/javascript" src="../zip-fs.js"></script>
+	<script type="text/javascript" src="../zip-ext.js"></script>
+	<script type="text/javascript" src="dataview.js"></script>
+	<script type="text/javascript" src="config.js"></script>
+	<script type="text/javascript" src="test20.js"></script>
+</body>
+</html>

--- a/WebContent/tests/test20.js
+++ b/WebContent/tests/test20.js
@@ -1,0 +1,38 @@
+var requestFileSystem = window.webkitRequestFileSystem || window.mozRequestFileSystem || window.msRequestFileSystem || window.requestFileSystem;
+var filesystem, zipFs = new zip.fs.FS();
+var THRESHOLD = 150;
+
+function onerror(message) {
+	console.error(message);
+}
+
+function generateFs(entry, onend, onerror) {
+	var i = 0;
+
+	function next() {
+		i++;
+		generateNextEntry();
+	}
+
+	function generateNextEntry() {
+		if (i <= THRESHOLD)
+			entry.getFile(i, {
+				create: true
+			}, next, onerror);
+		else
+			onend();
+	}
+
+	next();
+}
+
+function checkZipFileSystemSize() {
+	zipFs.root.addFileEntry(filesystem.root, function() {
+		console.log(zipFs.root.children.length === THRESHOLD);
+	}, onerror);
+}
+
+requestFileSystem(TEMPORARY, 4 * 1024 * 1024 * 1024, function(fs) {
+	filesystem = fs;
+	generateFs(filesystem.root, checkZipFileSystemSize, onerror);
+}, onerror);

--- a/WebContent/zip-fs.js
+++ b/WebContent/zip-fs.js
@@ -157,10 +157,23 @@
 
 	function addFileEntry(zipEntry, fileEntry, onend, onerror) {
 		function getChildren(fileEntry, callback) {
-			if (fileEntry.isDirectory)
-				fileEntry.createReader().readEntries(callback);
+			var entries = [];
+			if (fileEntry.isDirectory) {
+				var directoryReader = fileEntry.createReader();
+				function readEntries() {
+					directoryReader.readEntries(function(temporaryEntries) {
+						if (!temporaryEntries.length)
+							callback(entries);
+						else {
+							entries = entries.concat(temporaryEntries);
+							readEntries();
+						}
+					}, onerror);
+				}
+				readEntries();
+			}
 			if (fileEntry.isFile)
-				callback([]);
+				callback(entries);
 		}
 
 		function process(zipEntry, fileEntry, onend) {


### PR DESCRIPTION
the filesystem api specifies that readEntries needs to be called until no more results are returned.

this pull request fixes that.