### PR TITLE
Fixed SyntaxError: Functions cannot be declared in a nested block in …

### DIFF
--- a/WebContent/zip-fs.js
+++ b/WebContent/zip-fs.js
@@ -160,7 +160,7 @@
 			var entries = [];
 			if (fileEntry.isDirectory) {
 				var directoryReader = fileEntry.createReader();
-				function readEntries() {
+				(function readEntries() {
 					directoryReader.readEntries(function(temporaryEntries) {
 						if (!temporaryEntries.length)
 							callback(entries);
@@ -169,8 +169,7 @@
 							readEntries();
 						}
 					}, onerror);
-				}
-				readEntries();
+				})();
 			}
 			if (fileEntry.isFile)
 				callback(entries);


### PR DESCRIPTION
…strict mode #168.

https://github.com/gildas-lormeau/zip.js/issues/168

I'm trying to use this library on a project running with the headless browser PhantomJS 2.1 (http://phantomjs.org/)

But simply including this library into my project causes this error to appear when loading the javascript:
SyntaxError: Functions cannot be declared in a nested block in strict mode