### PR TITLE
Allow HttpReader to open cross-origin files with inaccessible headers

### DIFF
--- a/WebContent/zip-ext.js
+++ b/WebContent/zip-ext.js
@@ -42,6 +42,15 @@
 	} catch (e) {
 	}
 
+	function getLengthFromHeader(request) {
+		try {
+			return Number(request.getResponseHeader("Content-Length"));
+		} catch (e) {
+			window.console && console.warn(e + "");
+		}
+		return 0;
+	}
+
 	function HttpReader(url) {
 		var that = this;
 
@@ -51,7 +60,7 @@
 				request = new XMLHttpRequest();
 				request.addEventListener("load", function() {
 					if (!that.size)
-						that.size = Number(request.getResponseHeader("Content-Length")) || Number(request.response.byteLength);
+						that.size = getLengthFromHeader(request) || Number(request.response.byteLength);
 					that.data = new Uint8Array(request.response);
 					callback();
 				}, false);
@@ -66,7 +75,7 @@
 		function init(callback, onerror) {
 			var request = new XMLHttpRequest();
 			request.addEventListener("load", function() {
-				that.size = Number(request.getResponseHeader("Content-Length"));
+				that.size = getLengthFromHeader(request);
 				// If response header doesn't return size then prefetch the content.
 				if (!that.size) {
 					getData(callback, onerror);


### PR DESCRIPTION
If the CORS headers from server don't allow getting the response body but not the headers, `request.getResponseHeader("Content-Length")` will fail.

In such case we can simply pre-fetch the content the same way do it when the Content-Length header is not present:
https://github.com/gildas-lormeau/zip.js/commit/f7583c768fc4c2e1dd6460bd8332be369c447cbf
