### PR TITLE
Fix RollUp Errors

### DIFF
--- a/WebContent/deflate.js
+++ b/WebContent/deflate.js
@@ -2057,4 +2057,7 @@
 	// 'zip' may not be defined in z-worker and some tests
 	var env = global.zip || global;
 	env.Deflater = env._jzlib_Deflater = Deflater;
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window

--- a/WebContent/inflate.js
+++ b/WebContent/inflate.js
@@ -2152,4 +2152,7 @@
 	// 'zip' may not be defined in z-worker and some tests
 	var env = global.zip || global;
 	env.Inflater = env._jzlib_Inflater = Inflater;
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window

--- a/WebContent/pako/codecs.js
+++ b/WebContent/pako/codecs.js
@@ -61,4 +61,7 @@
 	var env = global.zip || global;
 	env.Deflater = env._pako_Deflater = Deflater;
 	env.Inflater = env._pako_Inflater = Inflater;
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window

--- a/WebContent/z-worker.js
+++ b/WebContent/z-worker.js
@@ -150,4 +150,7 @@
 		return bytes;
 	};
 	NOOP.prototype.flush = function flush() {};
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window

--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -963,4 +963,7 @@
 		workerScripts : null,
 	};
 
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window

--- a/WebContent/zlib-asm/codecs.js
+++ b/WebContent/zlib-asm/codecs.js
@@ -46,4 +46,7 @@
 	var env = global.zip || global;
 	env.Deflater = env._zlib_asm_Deflater = Deflater;
 	env.Inflater = env._zlib_asm_Inflater = Inflater;
-})(this);
+})(typeof self !== "undefined" && self || typeof window !== "undefined" && window || typeof global !== "undefined" && global || Function('return this.content')() || Function('return this')());
+// `self` is undefined in Firefox for Android content script context
+// while `this` is nsIContentFrameMessageManager
+// with an attribute `content` that corresponds to the window


### PR DESCRIPTION
The `this` keyword is equivalent to `undefined` at the top level of an ES (6?) module, and will be rewritten by rollup.

https://github.com/rollup/rollup/issues/847
https://github.com/eligrey/Blob.js/pull/56
https://github.com/MrRio/jsPDF/issues/1533