### PR TITLE
Add ZIP64 write support

### DIFF
--- a/WebContent/zip.js
+++ b/WebContent/zip.js
@@ -734,6 +734,9 @@
 			add : function(name, reader, onend, onprogress, options) {
 				var header, filename, date;
 				var worker = this._worker;
+				var zip64 = (options.zip64 ||
+										 datalength >= 0xffffffff ||
+										 !!(reader && reader.size >= 0xffffffff));
 
 				function writeHeader(callback) {
 					var data;
@@ -741,20 +744,35 @@
 					header = getDataHelper(26);
 					files[name] = {
 						headerArray : header.array,
+						extraArray : null,
 						directory : options.directory,
 						filename : filename,
 						offset : datalength,
 						comment : getBytes(encodeUTF8(options.comment || ""))
 					};
+					// 0: Min Version 
+					// 2: general purpose flags (bit 11: Utf-8 file names, bit 3: Data Descriptor flag)
 					header.view.setUint32(0, 0x14000808);
-					if (options.version)
-						header.view.setUint8(0, options.version);
+					// Zip64 minimum version
+					if (zip64)
+						header.view.setUint16(0, options.version && options.version > 45 ? options.version : 45, true);
+					else if (options.version)
+						header.view.setUint16(0, options.version, true);
+					// 4: Compression method
 					if (!dontDeflate && options.level !== 0 && !options.directory)
 						header.view.setUint16(4, 0x0800);
+					// 6: Time
 					header.view.setUint16(6, (((date.getHours() << 6) | date.getMinutes()) << 5) | date.getSeconds() / 2, true);
+					// 8: Data
 					header.view.setUint16(8, ((((date.getFullYear() - 1980) << 4) | (date.getMonth() + 1)) << 5) | date.getDate(), true);
+					// 10: crc32
+					// 14: compressed size
+					// 18: uncompressed size
+					// 22: file name length
 					header.view.setUint16(22, filename.length, true);
+					// 24: extra field length
 					data = getDataHelper(30 + filename.length);
+					// Local file header signature
 					data.view.setUint32(0, 0x504b0304);
 					data.array.set(header.array, 4);
 					data.array.set(filename, 30);
@@ -763,7 +781,13 @@
 				}
 
 				function writeFooter(compressedLength, crc32) {
-					var footer = getDataHelper(16);
+					if (compressedLength && compressedLength >= 0xffffffff) {
+						// Minimum version
+						header.view.setUint16(0, options.version && options.version > 45 ? options.version : 45);
+						zip64 = true;
+					}
+					// Data Descriptor
+					var footer = getDataHelper(zip64 ? 24 : 16);
 					datalength += compressedLength || 0;
 					footer.view.setUint32(0, 0x504b0708);
 					if (typeof crc32 != "undefined") {
@@ -771,13 +795,28 @@
 						footer.view.setUint32(4, crc32, true);
 					}
 					if (reader) {
-						footer.view.setUint32(8, compressedLength, true);
-						header.view.setUint32(14, compressedLength, true);
-						footer.view.setUint32(12, reader.size, true);
-						header.view.setUint32(18, reader.size, true);
+						if (zip64) {
+							let zip64Extra = getDataHelper(28);
+							header.view.setUint32(14, 0xffffffff, true);
+							header.view.setUint32(18, 0xffffffff, true);
+							footer.view.setBigUint64(8, BigInt(compressedLength), true);
+							footer.view.setBigUint64(16, BigInt(reader.size), true);
+							zip64Extra.view.setUint16(0, 0x0001, true);
+							zip64Extra.view.setUint16(2, 24, true);
+							zip64Extra.view.setBigUint64(4, BigInt(reader.size), true);
+							zip64Extra.view.setBigUint64(12, BigInt(compressedLength), true);
+							zip64Extra.view.setBigUint64(20, BigInt(files[name].offset), true);
+
+							files[name].extraArray = zip64Extra.array;
+						} else {
+							footer.view.setUint32(8, compressedLength, true);
+							header.view.setUint32(14, compressedLength, true);
+							footer.view.setUint32(12, reader.size, true);
+							header.view.setUint32(18, reader.size, true);
+						}
 					}
 					writer.writeUint8Array(footer.array, function() {
-						datalength += 16;
+						datalength += footer.array.length;
 						onend();
 					}, onwriteerror);
 				}
@@ -816,29 +855,101 @@
 				}
 
 				var data, length = 0, index = 0, indexFilename, file;
+				var zip64 = false, totalEntries = filenames.length, cdOffset = datalength;
 				for (indexFilename = 0; indexFilename < filenames.length; indexFilename++) {
 					file = files[filenames[indexFilename]];
 					length += 46 + file.filename.length + file.comment.length;
+					if (file.extraArray) {
+						length += file.extraArray.length;
+						zip64 = true;
+					}
 				}
-				data = getDataHelper(length + 22);
+				if (cdOffset + length >= 0xffffffff || totalEntries >= 0xffff)
+					zip64 = true;
+				data = getDataHelper(length + (zip64 ? 56 + 20 : 0) + 22);
 				for (indexFilename = 0; indexFilename < filenames.length; indexFilename++) {
 					file = files[filenames[indexFilename]];
+					// Central directory file header
+					// 0: Signature
 					data.view.setUint32(index, 0x504b0102);
-					data.view.setUint16(index + 4, 0x1400);
+					// 4: Version made by
+					data.view.setUint16(index + 4, 0x2d00);
+					// 6: same as local file header
 					data.array.set(file.headerArray, index + 6);
+					// 30: extra field length
+					if (file.extraArray)
+						data.view.setUint16(index + 30, file.extraArray.length, true);
+					// 32: file comment length
 					data.view.setUint16(index + 32, file.comment.length, true);
+					// 34: disk number start
+					// 36: internal file attributes
+					// 38: external file attributes
 					if (file.directory)
 						data.view.setUint8(index + 38, 0x10);
-					data.view.setUint32(index + 42, file.offset, true);
+					if (file.offset >= 0xffffffff)
+						data.view.setUint32(index + 42, 0xffffffff, true);
+					else
+						data.view.setUint32(index + 42, file.offset, true);
 					data.array.set(file.filename, index + 46);
-					data.array.set(file.comment, index + 46 + file.filename.length);
-					index += 46 + file.filename.length + file.comment.length;
+					let extraLength = 0
+					if (file.extraArray) {
+						extraLength = file.extraArray.length;
+						data.array.set(file.extraArray, index + 46 + file.filename.length);
+					}
+					data.array.set(file.comment, index + 46 + file.filename.length + extraLength);
+					index += 46 + file.filename.length + extraLength + file.comment.length;
 				}
+				if (zip64) {
+					// Zip64 End of Central Directory record
+					// 0: Signature
+					data.view.setUint32(index, 0x504b0606);
+					// 4: Size of zip64 EOCD
+					data.view.setBigUint64(index + 4, BigInt(44), true);
+					// 12: Version made By
+					data.view.setUint16(index + 12, 45, true);
+					// 14: version needed to extract
+					data.view.setUint16(index + 14, 45, true);
+					// 16: number of this disk
+					// 20: number of the disk with the start of CD
+					// 24: total number of entries in the central directory on this disk
+					data.view.setBigUint64(index + 24, BigInt(totalEntries), true);
+					// 32: total number of entries in the central directory
+					data.view.setBigUint64(index + 32, BigInt(totalEntries), true);
+					// 40: size of the central directory
+					data.view.setBigUint64(index + 40, BigInt(length), true);
+					// 48: Offset of start of central directory
+					data.view.setBigUint64(index + 48, BigInt(cdOffset), true);
+					index += 56
+
+					// Zip64 End of Central Directory locator
+					// 0: Signature
+					data.view.setUint32(index, 0x504b0607);
+					// 4: number of the disk with the zip64 EOCD
+					// 8: Offset of the zip64 EOCD
+					data.view.setBigUint64(index + 8, BigInt(cdOffset + length), true);
+					// 16: total number of disks
+					data.view.setUint32(index + 16, 1, true);
+					index += 20
+
+					// EOCD must set these values to 0xffff and 0xffffffff when using ZIP64 format
+					totalEntries = 0xffff;
+					cdOffset = 0xffffffff;
+					
+				}
+				// End of Central Directory record
+				// 0: Signature
 				data.view.setUint32(index, 0x504b0506);
-				data.view.setUint16(index + 8, filenames.length, true);
-				data.view.setUint16(index + 10, filenames.length, true);
+				// 4: Number of this disk
+				// 6: Number of the disk with the start of central directory
+				// 8: Total number of entries in the central directory on this disk
+				data.view.setUint16(index + 8, totalEntries, true);
+				// 10: total number of entries in the central directory
+				data.view.setUint16(index + 10, totalEntries, true);
+				// 12: size of the central directory
 				data.view.setUint32(index + 12, length, true);
-				data.view.setUint32(index + 16, datalength, true);
+				// 16: Offset of start of central directory
+				data.view.setUint32(index + 16, cdOffset, true);
+				// 20: .zip file comment length
 				writer.writeUint8Array(data.array, function() {
 					writer.getData(callback);
 				}, onwriteerror);


### PR DESCRIPTION
This adds zip64 support when writing files. 
I don't know if you still do pull requests or maintain the software, but at least others can find this if they need it.
When adding a file, there's a new `zip64` option that can be given which will force the file to be zip64, otherwise, it will automatically make it zip64 if it's size (compressed *or* uncompressed) is > 4GB or its position in the file is > 4GB, 
Same with the overall zip file itself, if the file ends up being > 4GB, it will use the zip64 format. 
Note that when a file that is added to the zip has to be saved with zip64, the `options.version` will get ignored if it's below 45 as that's the minimum version required for zip64 support.