### PR TITLE
fix: adapt type definition for NPM module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module "zip.js" {
+declare module "@zip.js/zip.js" {
 
     export function configure(configuration: ConfigurationOptions): void;
 


### PR DESCRIPTION
Should allow importing the module as `"@zip.js/zip.js"` without setting any path aliases in `tsconfig.json`.
Closes #214