### PR TITLE
Make HttpReader options parameter optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,11 +56,11 @@ declare module "@zip.js/zip.js" {
     }
 
     export class HttpReader extends Reader {
-        constructor(url: string, options: HttpOptions);
+        constructor(url: string, options?: HttpOptions);
     }
 
     export class HttpRangeReader extends Reader {
-        constructor(url: string, options: HttpRangeOptions);
+        constructor(url: string, options?: HttpRangeOptions);
     }
 
     export interface HttpOptions extends HttpRangeOptions {


### PR DESCRIPTION
The [documentation](https://gildas-lormeau.github.io/zip.js/core-api.html#io) states that the options parameter for both the `zip.HttpReader` and `zip.HttpRangeReader` constructor should be optional, however in the type definitions these are not optional causing TypeScript errors for valid code. This PR fixes this.


---

Thanks for making this and having a good documentation. This made it very easy to integrate into a project where I have to unpack small zip files within a worker.