### PR TITLE
fix crypto not defined when imported in node environment

### DIFF
--- a/lib/core/codecs/aes-crypto.js
+++ b/lib/core/codecs/aes-crypto.js
@@ -45,7 +45,6 @@ const SALT_LENGTH = [8, 12, 16];
 const KEY_LENGTH = [16, 24, 32];
 const SIGNATURE_LENGTH = 10;
 const COUNTER_DEFAULT_VALUE = [0, 0, 0, 0];
-const subtle = crypto.subtle;
 const codecBytes = codec.bytes;
 const Aes = cipher.aes;
 const CtrGladman = mode.ctrGladman;
@@ -188,8 +187,8 @@ async function createEncryptionKeys(encrypt, password) {
 
 async function createKeys(target, password, salt) {
 	const encodedPassword = (new TextEncoder()).encode(password);
-	const basekey = await subtle.importKey(RAW_FORMAT, encodedPassword, BASE_KEY_ALGORITHM, false, DERIVED_BITS_USAGE);
-	const derivedBits = await subtle.deriveBits(Object.assign({ salt }, DERIVED_BITS_ALGORITHM), basekey, 8 * ((KEY_LENGTH[target.strength] * 2) + 2));
+	const basekey = await crypto.subtle.importKey(RAW_FORMAT, encodedPassword, BASE_KEY_ALGORITHM, false, DERIVED_BITS_USAGE);
+	const derivedBits = await crypto.subtle.deriveBits(Object.assign({ salt }, DERIVED_BITS_ALGORITHM), basekey, 8 * ((KEY_LENGTH[target.strength] * 2) + 2));
 	const compositeKey = new Uint8Array(derivedBits);
 	target.keys = {
 		key: codecBytes.toBits(subarray(compositeKey, 0, KEY_LENGTH[target.strength])),


### PR DESCRIPTION
Hello! Found that while running a project using this library that our test runner (mocha in this case) was failing due to crypto not being found.

While I understand the package itself is meant to work in the browser, the error is introduced as a side-effect on import, meaning that everything that uses this package ended up failing even if the zip functionality wasn't directly called. It wasn't possible to resolve via mocking unless we globally mocked crypto in all our test suites, which was not ideal.

This minor change fixes the problem but happy to introduce other solutions if this isn't satisfactory! Thanks!