### PR TITLE
Fix TypeScript definition for ZipWriter.add

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,7 @@ declare module "@zip.js/zip.js" {
     export class ZipWriter {
         readonly hasCorruptedEntries?: boolean;
         constructor(writer: Writer, options?: ZipWriterConstructorOptions);
-        public add(name: string, reader: Reader, options?: ZipWriterAddDataOptions): Promise<Entry>;
+        public add(name: string, reader: Reader | null, options?: ZipWriterAddDataOptions): Promise<Entry>;
         public close(comment?: Uint8Array, options?: ZipWriterCloseOptions): Promise<any>;
     }
 


### PR DESCRIPTION
The [docs for the `add` method of ZipWriter](https://gildas-lormeau.github.io/zip.js/core-api.html#zip-writing) specify this for the `reader` parameter:

> reader (zip.Reader)
> &nbsp;&nbsp;&nbsp;&nbsp;The zip.Reader object used to read entry data to add - null for directory entry

However the TypeScript definitions currently don't support allow passing `null` - this PR fixes that.