### PR TITLE
Fix TypeScript definition for TextWriter.getData

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare module "@zip.js/zip.js" {
 
     export class TextWriter extends Writer {
         constructor(encoding?: string);
-        public getData(): string;
+        public getData(): Promise<string>;
     }
 
     export class BlobWriter extends Writer {


### PR DESCRIPTION
Appears that `TextWriter.getData` returns a `Promise<string>` instead of a `string`:

https://github.com/gildas-lormeau/zip.js/blob/78a80d20f7fbdb90301e2a676d7c7135de5fc771/lib/core/io.js#L98-L106