### PR TITLE
Update demo code for "Write a zip into a Blob object"

### DIFF
--- a/core-api.html
+++ b/core-api.html
@@ -773,7 +773,7 @@ await writer.add("filename.txt", new zip.TextReader("test!"));
 await writer.close();
 
 // get the zip file as a Blob
-const blob = await blobWriter.getData();</code></pre>
+const blob = blobWriter.getData();</code></pre>
 		<h2 id="full-example">Full example</h2>
 		<pre><code class="prettyprint">// - create the inputBlob object storing the data to compress
 const inputBlob = new Blob(


### PR DESCRIPTION
Appears that `BlobWriter.getData` returns a `Blob` and not a `Promise<Blob>` (which matches the existing [type definition](https://github.com/gildas-lormeau/zip.js/blob/78a80d20f7fbdb90301e2a676d7c7135de5fc771/index.d.ts#L88)):

https://github.com/gildas-lormeau/zip.js/blob/78a80d20f7fbdb90301e2a676d7c7135de5fc771/index.d.ts#L88

So I've updated the example code to match.