### PR TITLE
Fix corrupt zips for certain inputs

### DIFF
--- a/lib/core/codecs/deflate.js
+++ b/lib/core/codecs/deflate.js
@@ -1673,7 +1673,7 @@ function Deflate() {
 		that.pending_buf = new Uint8Array(lit_bufsize * 4);
 		pending_buf_size = lit_bufsize * 4;
 
-		d_buf = Math.floor(lit_bufsize / 2);
+		d_buf = lit_bufsize;
 		l_buf = (1 + 2) * lit_bufsize;
 
 		level = _level;


### PR DESCRIPTION
This is applying the fix for https://github.com/ymnk/jzlib/issues/9 from https://github.com/ymnk/jzlib/commit/8b205d660d37503f71d4b1bbbc9779925ed14e8d.

This bug was introduced when zlib (written in C) was incorrectly ported to jzlib (in Java), which was later ported to zip.js.
Equivalent line in zlib: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/deflate.c#L340 (in C, adding a number to a pointer adds sizeof(type) many bytes).

We are using an older version of zip.js and were hit by this bug for some rare inputs. The bug causes the corresponding zip entries to get corrupted and truncated because the range in `pending_buf` used as output buffer overlaps with the range used for distances for certain input patterns (when `that.pending >= d_buf + lx*2`).