### PR TITLE
Fix corrupt zips for certain inputs (clean fix)

### DIFF
--- a/lib/core/codecs/deflate.js
+++ b/lib/core/codecs/deflate.js
@@ -484,6 +484,12 @@ function Deflate() {
 	let pending_buf_size; // size of pending_buf
 	// pending_out; // next pending byte to output to the stream
 	// pending; // nb of bytes in the pending buffer
+
+	// dist_buf; // buffer for distances
+	// lc_buf; // buffer for literals or lengths
+	// To simplify the code, dist_buf and lc_buf have the same number of elements.
+	// To use different lengths, an extra flag array would be necessary.
+
 	let last_flush; // value of flush param for previous deflate call
 
 	let w_size; // LZ77 window size (32K by default)
@@ -575,8 +581,6 @@ function Deflate() {
 	// Depth of each subtree used as tie breaker for trees of equal frequency
 	that.depth = [];
 
-	let l_buf; // index for literals or lengths */
-
 	// Size of match buffer for literals/lengths. There are 4 reasons for
 	// limiting lit_bufsize to 64K:
 	// - frequencies can be kept in 16 bit counters
@@ -596,13 +600,7 @@ function Deflate() {
 	// - I can't count above 4
 	let lit_bufsize;
 
-	let last_lit; // running index in l_buf
-
-	// Buffer for distances. To simplify the code, d_buf and l_buf have
-	// the same number of elements. To use different lengths, an extra flag
-	// array would be necessary.
-
-	let d_buf; // index of pendig_buf
+	let last_lit; // running index in dist_buf and lc_buf
 
 	// that.opt_len; // bit length of current block with optimal trees
 	// that.static_len; // bit length of current block with static trees
@@ -946,10 +944,8 @@ function Deflate() {
 		lc // match length-MIN_MATCH or unmatched char (if dist==0)
 	) {
 		let out_length, in_length, dcode;
-		that.pending_buf[d_buf + last_lit * 2] = (dist >>> 8) & 0xff;
-		that.pending_buf[d_buf + last_lit * 2 + 1] = dist & 0xff;
-
-		that.pending_buf[l_buf + last_lit] = lc & 0xff;
+		that.dist_buf[last_lit] = dist;
+		that.lc_buf[last_lit] = lc & 0xff;
 		last_lit++;
 
 		if (dist === 0) {
@@ -985,14 +981,14 @@ function Deflate() {
 	function compress_block(ltree, dtree) {
 		let dist; // distance of matched string
 		let lc; // match length or unmatched char (if dist === 0)
-		let lx = 0; // running index in l_buf
+		let lx = 0; // running index in dist_buf and lc_buf
 		let code; // the code to send
 		let extra; // number of extra bits to send
 
 		if (last_lit !== 0) {
 			do {
-				dist = ((that.pending_buf[d_buf + lx * 2] << 8) & 0xff00) | (that.pending_buf[d_buf + lx * 2 + 1] & 0xff);
-				lc = (that.pending_buf[l_buf + lx]) & 0xff;
+				dist = that.dist_buf[lx];
+				lc = that.lc_buf[lx];
 				lx++;
 
 				if (dist === 0) {
@@ -1018,9 +1014,6 @@ function Deflate() {
 						send_bits(dist, extra); // send the extra distance bits
 					}
 				} // literal or match pair ?
-
-				// Check that the overlay between pending_buf and d_buf+l_buf is
-				// ok:
 			} while (lx < last_lit);
 		}
 
@@ -1668,13 +1661,11 @@ function Deflate() {
 
 		lit_bufsize = 1 << (memLevel + 6); // 16K elements by default
 
-		// We overlay pending_buf and d_buf+l_buf. This works since the average
-		// output size for (length,distance) codes is <= 24 bits.
 		that.pending_buf = new Uint8Array(lit_bufsize * 4);
 		pending_buf_size = lit_bufsize * 4;
 
-		d_buf = Math.floor(lit_bufsize / 2);
-		l_buf = (1 + 2) * lit_bufsize;
+		that.dist_buf = new Uint16Array(lit_bufsize);
+		that.lc_buf = new Uint8Array(lit_bufsize);
 
 		level = _level;
 
@@ -1688,6 +1679,8 @@ function Deflate() {
 			return Z_STREAM_ERROR;
 		}
 		// Deallocate in reverse order of allocations:
+		that.lc_buf = null;
+		that.dist_buf = null;
 		that.pending_buf = null;
 		head = null;
 		prev = null;


### PR DESCRIPTION
This is a cleaner version of the fix in https://github.com/gildas-lormeau/zip.js/pull/302 that separates `pending_buf` -- which is used simultaneously for 3 different buffers as an optimisation -- into 3 separate arrays. This improves maintainability and readability of the code (reducing the likelihood of introducing bugs such as this one) at the cost of 48 KiB additional memory, which I would argue is a worthwhile trade-off for a JS implementation.