### PR TITLE
rewrite ZipReader getEntries by getEntriesGenerator generator function.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,7 @@ declare module "@zip.js/zip.js" {
     export class ZipReader {
         constructor(reader: Reader, options?: ZipReaderConstructorOptions);
         getEntries(options?: ZipReaderGetEntriesOptions): Promise<Entry[]>;
+        *getEntriesGenerator(options?: ZipReaderGetEntriesOptions): AsyncGenerator<Entry, boolean>;
         close(): Promise<any>;
     }
 

--- a/lib/core/zip-reader.js
+++ b/lib/core/zip-reader.js
@@ -87,7 +87,7 @@ class ZipReader {
 		});
 	}
 
-	async getEntries(options = {}) {
+	async* getEntriesGenerator(options = {}) {
 		const zipReader = this;
 		const reader = zipReader.reader;
 		if (!reader.initialized) {
@@ -148,7 +148,6 @@ class ZipReader {
 		if (directoryDataOffset < 0 || directoryDataOffset >= reader.size) {
 			throw new Error(ERR_BAD_FORMAT);
 		}
-		const entries = [];
 		for (let indexFile = 0; indexFile < filesLength; indexFile++) {
 			const fileEntry = new ZipEntry(reader, zipReader.config, zipReader.options);
 			if (getUint32(directoryView, offset) != CENTRAL_FILE_HEADER_SIGNATURE) {
@@ -192,7 +191,6 @@ class ZipReader {
 			await readCommonFooter(fileEntry, fileEntry, directoryView, offset + 6);
 			const entry = new Entry(fileEntry);
 			entry.getData = (writer, options) => fileEntry.getData(writer, entry, options);
-			entries.push(entry);
 			offset = endOffset;
 			if (options.onprogress) {
 				try {
@@ -201,6 +199,18 @@ class ZipReader {
 					// ignored
 				}
 			}
+			yield entry;
+		}
+		return true;
+	}
+
+	async getEntries(options = {}) {
+		const entries = [];
+		const iter = this.getEntriesGenerator(options);
+		let curr = iter.next();
+		while(!(await curr).done) {
+			entries.push((await curr).value);
+			curr = iter.next();
 		}
 		return entries;
 	}


### PR DESCRIPTION
ZipReader.getEntries returns all entries at once. It could cause out of memory while reading large zip file on mobile devices with few free RAMs.

For example, I have a book reader app - [cbetar2](https://github.com/MrMYHuang/cbetar2). It supports to import a 1.2 GB zip of books to IndexedDB and provide the offline navigation capability. The zip:
https://drive.google.com/file/d/1SREFB4Es7Rf-AuxvgFO_u2KwAJcnEHJP/view

The app is designed to work on iOS and Android devices. Thanks to zip.js, which can read large file on those small RAM devices, e.g., my iPad Pro 2GB RAM and my hTC Android phone 6GB RAM.
The original ZipReader.getEntries works well on my iPad, but crashes on my Android phone. I think it still consumes much RAM. Thus, I rewrite it by JavaScript generator function. A new added generator function *getEntry can let my app to process each entry in zip at a time:
https://github.com/MrMYHuang/cbetar2/blob/be947a115b567224004a2ee4e12bcc3d37dc4f30/src/IndexedDbFuncs.ts#L128-L145
Fortunately, it works on my Android phone.