### PR TITLE
Make useCompressionStream optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare global {
 
 interface ConfigurationOptions {
     useWebWorkers?: boolean;
-    useCompressionStream: boolean;
+    useCompressionStream?: boolean;
     maxWorkers?: number;
     terminateWorkerTimeout?: number;
     workerScripts?: {


### PR DESCRIPTION
When [I try to update zip.js to the latest version](https://github.com/tim-we/web-ext-inspector/pull/26) I get the following error: 

    TS2345: Argument of type '{ useWebWorkers: false; }' is not assignable to parameter of type 'ConfigurationOptions'.
    Property 'useCompressionStream' is missing in type '{ useWebWorkers: false; }' but required in type 'ConfigurationOptions'

The [documentation](https://gildas-lormeau.github.io/zip.js/core-api.html#configuration) says that all the configuration properties are optional. So I made `useCompressionStream` optional.