### PR TITLE
Update types of optional dependencies

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -821,7 +821,7 @@ export class ZipWriter<Type> {
      * @param options The options.
      * @returns A promise resolving to an `Entry` instance.
      */
-    add<ReaderType>(filename: string, reader: Reader<ReaderType> | ReadableReader | null | undefined, options?: ZipWriterAddDataOptions): Promise<Entry>
+    add<ReaderType>(filename: string, reader?: Reader<ReaderType> | ReadableReader | null, options?: ZipWriterAddDataOptions): Promise<Entry>
     /**
      * Writes the entries directory, writes the global comment, and returns the content of the zip file
      * 
@@ -829,7 +829,7 @@ export class ZipWriter<Type> {
      * @param options The options.
      * @returns The content of the zip file.
      */
-    close(comment: Uint8Array | null | undefined, options?: ZipWriterCloseOptions): Promise<Type>
+    close(comment?: Uint8Array | null, options?: ZipWriterCloseOptions): Promise<Type>
 }
 
 /**
@@ -1088,7 +1088,7 @@ export class ZipFileEntry<ReaderType, WriterType> extends ZipEntry {
      * @param options The options.
      * @returns A promise resolving to a `string`.
      */
-    getText(encoding: string | null | undefined, options?: EntryGetDataOptions): Promise<string>
+    getText(encoding?: string | null, options?: EntryGetDataOptions): Promise<string>
     /**
      * Retrieves the content of the entry as a `Blob` instance
      * 
@@ -1096,7 +1096,7 @@ export class ZipFileEntry<ReaderType, WriterType> extends ZipEntry {
      * @param options The options.
      * @returns A promise resolving to a `Blob` instance.
      */
-    getBlob(mimeType: string | null | undefined, options?: EntryGetDataOptions): Promise<Blob>
+    getBlob(mimeType?: string | null, options?: EntryGetDataOptions): Promise<Blob>
     /**
      * Retrieves the content of the entry as as a Data URI `string` encoded in Base64
      * 
@@ -1104,7 +1104,7 @@ export class ZipFileEntry<ReaderType, WriterType> extends ZipEntry {
      * @param options The options.
      * @returns A promise resolving to a Data URI `string` encoded in Base64.
      */
-    getData64URI(mimeType: string | null | undefined, options?: EntryGetDataOptions): Promise<string>
+    getData64URI(mimeType?: string | null, options?: EntryGetDataOptions): Promise<string>
     /**
      * Retrieves the content of the entry as a `Uint8Array` instance
      * 
@@ -1119,7 +1119,7 @@ export class ZipFileEntry<ReaderType, WriterType> extends ZipEntry {
      * @param options The options.
      * @returns A promise resolving to the `WritableStream` instance.
      */
-    getWritable(writable: WritableStream | null | undefined, options?: EntryGetDataOptions): Promise<WritableStream>
+    getWritable(writable?: WritableStream | null, options?: EntryGetDataOptions): Promise<WritableStream>
     /**
      * Retrieves the content of the entry via a `Writer` instance
      * 
@@ -1301,7 +1301,7 @@ export class ZipDirectoryEntry extends ZipEntry {
      * @param options  The options.
      * @returns A promise resolving to the `Uint8Array` instance.
      */
-    exportWritable(writable: WritableStream | null | undefined, options?: ZipDirectoryEntryExportOptions): Promise<WritableStream>
+    exportWritable(writable?: WritableStream | null, options?: ZipDirectoryEntryExportOptions): Promise<WritableStream>
 }
 
 /**


### PR DESCRIPTION
A recent update caused one of my projects to fail TypeScript compilation with the following error:

```
Failed to compile.
TS2554: Expected 1-2 arguments, but got 0.
    46 |   );
    47 |
  > 48 |   await zipWriter.close();
       |                   ^^^^^^^
    49 |
    50 |   return blobWriter.getData();
    51 | }
```

I believe this issue is the result of 1dc2835976bbe009646f72b13196af97269bb70d, which I've attempted to address in this PR, by marking such parameters as optional instead of `| undefined`.