### PR TITLE
make getData always available in Entry

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -858,7 +858,7 @@ export interface Entry {
      * @param options The options.
      * @returns A promise resolving to the type to data associated to `writer`.
      */
-    getData?<Type>(writer: Writer<Type> | WritableWriter | WritableStream | AsyncGenerator<Writer<unknown> | WritableWriter | WritableStream, boolean>, options?: EntryGetDataOptions): Promise<Type>
+    getData<Type>(writer: Writer<Type> | WritableWriter | WritableStream | AsyncGenerator<Writer<unknown> | WritableWriter | WritableStream, boolean>, options?: EntryGetDataOptions): Promise<Type>
 }
 
 /**


### PR DESCRIPTION
I'm pretty sure the `getData` method is always available in the Entry object after reading the code so this change will reflect that in the typings.