### PR TITLE
Add preventHeadRequest=false and combineSizeEocd Typescript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -441,10 +441,17 @@ export interface HttpOptions extends HttpRangeOptions {
   forceRangeRequests?: boolean;
   /**
    * `true` to prevent using `HEAD` HTTP request in order the get the size of the content.
+   * `false` to explicitly use `HEAD`, this is useful in case of CORS where `Access-Control-Expose-Headers: Content-Range` is not returned by the server.
    *
    * @defaultValue false
    */
   preventHeadRequest?: boolean;
+  /**
+   * `true` to use `Range: bytes=-22` on the first request and cache the EOCD, make sure beforehand that the server supports a suffix range request.
+   *
+   * @defaultValue false
+   */
+  combineSizeEocd?: boolean;
 }
 
 /**

--- a/lib/core/io.js
+++ b/lib/core/io.js
@@ -315,10 +315,11 @@ function createHttpReader(httpReader, url, options) {
 async function initHttpReader(httpReader, sendRequest, getRequestData) {
 	const {
 		url,
+		preventHeadRequest,
 		useRangeHeader,
 		forceRangeRequests
 	} = httpReader;
-	if (isHttpFamily(url) && (useRangeHeader || forceRangeRequests)) {
+	if (isHttpFamily(url) && (useRangeHeader || forceRangeRequests) && (typeof preventHeadRequest == "undefined" || preventHeadRequest)) {
 		const { headers } = await sendRequest(HTTP_METHOD_GET, httpReader, getRangeHeaders(httpReader));
 		if (!forceRangeRequests && headers.get(HTTP_HEADER_ACCEPT_RANGES) != HTTP_RANGE_UNIT) {
 			throw new Error(ERR_HTTP_RANGE);

--- a/lib/core/io.js
+++ b/lib/core/io.js
@@ -31,7 +31,8 @@
 
 import {
 	UNDEFINED_VALUE,
-	FUNCTION_TYPE
+	FUNCTION_TYPE,
+	END_OF_CENTRAL_DIR_LENGTH
 } from "./constants.js";
 import { getConfiguration } from "./configuration.js";
 
@@ -296,19 +297,22 @@ function createHttpReader(httpReader, url, options) {
 	const {
 		preventHeadRequest,
 		useRangeHeader,
-		forceRangeRequests
+		forceRangeRequests,
+		combineSizeEocd
 	} = options;
 	options = Object.assign({}, options);
 	delete options.preventHeadRequest;
 	delete options.useRangeHeader;
 	delete options.forceRangeRequests;
+	delete options.combineSizeEocd;
 	delete options.useXHR;
 	Object.assign(httpReader, {
 		url,
 		options,
 		preventHeadRequest,
 		useRangeHeader,
-		forceRangeRequests
+		forceRangeRequests,
+		combineSizeEocd
 	});
 }
 
@@ -317,15 +321,19 @@ async function initHttpReader(httpReader, sendRequest, getRequestData) {
 		url,
 		preventHeadRequest,
 		useRangeHeader,
-		forceRangeRequests
+		forceRangeRequests,
+		combineSizeEocd
 	} = httpReader;
 	if (isHttpFamily(url) && (useRangeHeader || forceRangeRequests) && (typeof preventHeadRequest == "undefined" || preventHeadRequest)) {
-		const { headers } = await sendRequest(HTTP_METHOD_GET, httpReader, getRangeHeaders(httpReader));
-		if (!forceRangeRequests && headers.get(HTTP_HEADER_ACCEPT_RANGES) != HTTP_RANGE_UNIT) {
+		const response = await sendRequest(HTTP_METHOD_GET, httpReader, getRangeHeaders(httpReader, combineSizeEocd ? -END_OF_CENTRAL_DIR_LENGTH : undefined));
+		if (!forceRangeRequests && response.headers.get(HTTP_HEADER_ACCEPT_RANGES) != HTTP_RANGE_UNIT) {
 			throw new Error(ERR_HTTP_RANGE);
 		} else {
+			if (combineSizeEocd) {
+				httpReader.eocdCache = new Uint8Array(await response.arrayBuffer());
+			}
 			let contentSize;
-			const contentRangeHeader = headers.get(HTTP_HEADER_CONTENT_RANGE);
+			const contentRangeHeader = response.headers.get(HTTP_HEADER_CONTENT_RANGE);
 			if (contentRangeHeader) {
 				const splitHeader = contentRangeHeader.trim().split(/\s*\/\s*/);
 				if (splitHeader.length) {
@@ -350,9 +358,14 @@ async function readUint8ArrayHttpReader(httpReader, index, length, sendRequest, 
 	const {
 		useRangeHeader,
 		forceRangeRequests,
+		eocdCache,
+		size,
 		options
 	} = httpReader;
 	if (useRangeHeader || forceRangeRequests) {
+		if (eocdCache && index == size - END_OF_CENTRAL_DIR_LENGTH && length == END_OF_CENTRAL_DIR_LENGTH) {
+			return eocdCache;
+		}
 		const response = await sendRequest(HTTP_METHOD_GET, httpReader, getRangeHeaders(httpReader, index, length));
 		if (response.status != 206) {
 			throw new Error(ERR_HTTP_RANGE);
@@ -368,7 +381,7 @@ async function readUint8ArrayHttpReader(httpReader, index, length, sendRequest, 
 }
 
 function getRangeHeaders(httpReader, index = 0, length = 1) {
-	return Object.assign({}, getHeaders(httpReader), { [HTTP_HEADER_RANGE]: HTTP_RANGE_UNIT + "=" + index + "-" + (index + length - 1) });
+	return Object.assign({}, getHeaders(httpReader), { [HTTP_HEADER_RANGE]: HTTP_RANGE_UNIT + "=" + (index < 0 ? index : index + "-" + (index + length - 1)) });
 }
 
 function getHeaders({ options }) {


### PR DESCRIPTION
Fix #498 - third part, add typescript definitions.

The case `@defaultValue false` is not really true for `preventHeadRequest` with an explicit 'is not undefined and false' check.