### PR TITLE
fix type of Entry#extraField

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -926,7 +926,7 @@ export interface EntryMetaData {
   /**
    * The extra field.
    */
-  extraField?: Map<number, Uint8Array>;
+  extraField?: Map<number, { type: number, data: Uint8Array }>;
   /**
    * The extra field (raw).
    */


### PR DESCRIPTION
As per `readCommonFooter`, `Entry#extraField` is of ` Map<number, { type: number, data: Uint8Array }>`

https://github.com/gildas-lormeau/zip.js/blob/86198bb209ddd1f2c8c3d247d77c8dc0ec7f5cd7/lib/core/zip-reader.js?plain=1#L528-L531

But was typed as `Map<number, Uint8Array>`
https://github.com/gildas-lormeau/zip.js/blob/86198bb209ddd1f2c8c3d247d77c8dc0ec7f5cd7/index.d.ts#L929

This PR fixes the type.