### PR TITLE
fix: type of Uint8ArrayWriter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -783,9 +783,9 @@ export class SplitDataWriter implements Initializable, WritableWriter {
 }
 
 /**
- * Represents a {@link Writer}  instance used to retrieve the written data as a `Uint8Array` instance.
+ * Represents a {@link Writer} instance used to retrieve the written data as a `Uint8Array` instance.
  */
-export class Uint8ArrayWriter extends Writer<Uint8Array> {}
+export class Uint8ArrayWriter extends Writer<Uint8Array<ArrayBuffer>> {}
 
 /**
  * Represents an instance used to create an unzipped stream.


### PR DESCRIPTION
There was a breaking change in TypeScript 5.9 that affects the default type of `Uint8Array`.
`Uint8ArrayWriter` always creates a `Uint8Array` using the `size` argument, which guarantees to initialize an `ArrayBuffer`.

Refs: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes
