### PR TITLE
Export web workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   "types": "./index.d.ts",
   "exports": {
     "./package.json": "./package.json",
+    "./dist/zip-web-worker.js": "./dist/zip-web-worker.js",
+    "./dist/zip-module.wasm": "./dist/zip-module.wasm",
     ".": {
       "import": {
         "types": "./index.d.ts",


### PR DESCRIPTION
Exports the compiled web worker and web assembly files so they can be imported and self hosted.

### Problem:
The default configuration attempts to create a worker from an arbitrary javascript data blob which is blocked by strict content security policies:
```
Refused to create a worker from 'data:text/javascript...'
```

Strict content security policies prevent creating a web worker from a data blob (data:text/javascript,...) without hashes/nonces.

By allowing the web worker and assembly files to be imported by consumers (like vite/rollup), they can be self-hosted, conforming to a standard/simple CSP.

### Example:

```
import workerURI from "@zip.js/zip.js/dist/zip-web-worker.js?url";
import wasmURI from "@zip.js/zip.js/dist/zip-module.wasm?url";

configure({
  useWebWorkers: true,
  workerURI,
  wasmURI
});
```