### PR TITLE
Add missing typings for `useWebWorkers` and `useCompressionStream` to ZipWriterConstructorOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1396,7 +1396,7 @@ export interface ZipWriterCloseOptions extends EntryOnprogressOptions {
 /**
  * Represents options passed to the constructor of {@link ZipWriter}, {@link ZipWriter#add} and `{@link ZipDirectoryEntry}#export*`.
  */
-export interface ZipWriterConstructorOptions {
+export interface ZipWriterConstructorOptions extends WorkerConfiguration {
   /**
    * `true` to use Zip64 to store the entry.
    *


### PR DESCRIPTION
Hi,

I found that ZipWriter options is currently missing typings for `useWebWorkers` and `useCompressionStream` which are supported by the runtime code.

Making ZipWriterConstructorOptions extend WorkerConfiguration seems to be the best way of implementing this.
