### PR TITLE
Specify charset in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
 			</li>
 			<li>or as a regular script:
-				<pre><code class="prettyprint">&lt;script type=&quot;text/javascript&quot; src=&quot;/library_path/zip.min.js&quot;&gt;
+				<pre><code class="prettyprint">&lt;script type=&quot;text/javascript&quot; charset=&quot;utf-8&quot; src=&quot;/library_path/zip.min.js&quot;&gt;
 &lt;/script&gt;
 &lt;script&gt;
   // the zip API is in the `zip` global variable


### PR DESCRIPTION
In the "regular script" example, specify the charset as "utf-8". This was mentioned a few paragraphs back (as discussed in #352), yet I missed it and didn't realize it until too late. Hopefully this change helps others like me.

Edit: by "too late" I mean I spent hours wondering why the filenames were garbled, and then figuring out that "utf-8", "ibm866", and even "gb2312" worked, and only "cp437" didn't. Then I searched the issues and found #352.