### PR TITLE
Fix Markdown syntax in `ZipWriterConstructorOptions.dataDescriptor`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1529,9 +1529,9 @@ export interface ZipWriterConstructorOptions extends WorkerConfiguration {
   /**
    * `true` to add a data descriptor.
    *
-   * When set to `false`, the {@link ZipWriterConstructorOptions#bufferedWrite} option  will automatically be
+   * When set to `false`, the {@link ZipWriterConstructorOptions#bufferedWrite} option will automatically be
    * set to `true`. It will be automatically set to `false` when it is `undefined` and the
-   * {@link ZipWriterConstructorOptions#bufferedWrite} option is set to `true`, or ` when the
+   * {@link ZipWriterConstructorOptions#bufferedWrite} option is set to `true`, or when the
    * {@link ZipWriterConstructorOptions#zipCrypto} option is set to `true`. Otherwise, the default value is `true`.
    */
   dataDescriptor?: boolean;


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Before](https://github.com/user-attachments/assets/0da356ce-2c82-49d5-9bdb-97eeec7b5fe6) | ![After](https://github.com/user-attachments/assets/73c398c2-d758-4ad4-adce-97bed88bc17e) |
