### PR TITLE
fix: bound getData() memory with ByteLengthQueuingStrategy on internal transforms

### DIFF
--- a/lib/core/codec-worker.js
+++ b/lib/core/codec-worker.js
@@ -26,7 +26,7 @@
  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* global Worker, URL, TransformStream, WritableStream */
+/* global Worker, URL, TransformStream, WritableStream, ByteLengthQueuingStrategy */
 
 import {
 	UNDEFINED_VALUE,
@@ -72,7 +72,7 @@ class CodecWorker {
 			busy: true,
 			readable: readable
 				.pipeThrough(new ChunkStream(config.chunkSize))
-				.pipeThrough(new ProgressWatcherStream(streamOptions), { signal }),
+				.pipeThrough(new ProgressWatcherStream(streamOptions, config.chunkSize), { signal }),
 			writable,
 			options: Object.assign({}, options),
 			workerURI,
@@ -115,8 +115,9 @@ class CodecWorker {
 
 class ProgressWatcherStream extends TransformStream {
 
-	constructor({ onstart, onprogress, size, onend }) {
+	constructor({ onstart, onprogress, size, onend }, chunkSize) {
 		let chunkOffset = 0;
+		const byteStrategy = new ByteLengthQueuingStrategy({ highWaterMark: chunkSize });
 		super({
 			async start() {
 				if (onstart) {
@@ -135,7 +136,7 @@ class ProgressWatcherStream extends TransformStream {
 					await callHandler(onend, chunkOffset);
 				}
 			}
-		});
+		}, byteStrategy, byteStrategy);
 	}
 }
 

--- a/lib/core/streams/codec-stream.js
+++ b/lib/core/streams/codec-stream.js
@@ -33,7 +33,7 @@
  * and contributors of zlib.
  */
 
-/* global TransformStream */
+/* global TransformStream, ByteLengthQueuingStrategy */
 // deno-lint-ignore-file no-this-alias
 
 import { UNDEFINED_VALUE } from "../constants.js";
@@ -88,6 +88,7 @@ class CodecStream extends TransformStream {
 		let inputSize = 0;
 		const stream = new Stream(options, config);
 		const readable = super.readable;
+		const byteStrategy = new ByteLengthQueuingStrategy({ highWaterMark: config.chunkSize });
 		const inputSizeStream = new TransformStream({
 			transform(chunk, controller) {
 				if (chunk && chunk.length) {
@@ -100,7 +101,7 @@ class CodecStream extends TransformStream {
 					inputSize
 				});
 			}
-		});
+		}, byteStrategy, byteStrategy);
 		const outputSizeStream = new TransformStream({
 			transform(chunk, controller) {
 				if (chunk && chunk.length) {
@@ -118,7 +119,7 @@ class CodecStream extends TransformStream {
 					inputSize
 				});
 			}
-		});
+		}, byteStrategy, byteStrategy);
 		Object.defineProperty(codec, "readable", {
 			get() {
 				return readable.pipeThrough(inputSizeStream).pipeThrough(stream).pipeThrough(outputSizeStream);


### PR DESCRIPTION
Fixes #658.

## What

Apply `ByteLengthQueuingStrategy({ highWaterMark: config.chunkSize })` to both sides of the three internal `TransformStream` stages that currently use the default `CountQueuingStrategy`:

- `inputSizeStream` in `lib/core/streams/codec-stream.js`
- `outputSizeStream` in `lib/core/streams/codec-stream.js`
- `ProgressWatcherStream` in `lib/core/codec-worker.js`

## Why

`CountQueuingStrategy({highWaterMark:1})` bounds the backlog by **chunk count**, not bytes. With zip.js's default 512 KB `chunkSize`, a single pending chunk per stage means the decompressed output can accumulate without limit when the destination `WritableStream` drains slower than inflation completes.

On a Cloudflare Workers isolate (128 MB hard limit) this causes an OOM crash for entries above ~2.7 GB. A 512 MB entry piped to a 50 MB/s sink showed ~512 MB peak in-flight before the destination caught up.

`ByteLengthQueuingStrategy` with the same `highWaterMark` as `chunkSize` matches the chunk granularity already established by `ChunkStream` upstream, so backpressure now propagates in bytes rather than count.

## Verification

Interactive demo showing all three approaches (current / this fix / `DecompressionStream` workaround) side-by-side:
https://github.com/cwoodcox/zipjs-backpressure-repro

The `DecompressionStream` panel demonstrates the fix shape: same entry, same slow sink, ~0 MB in-flight throughout.

## Change size

~20 lines across two files. No new dependencies; `ByteLengthQueuingStrategy` is a WHATWG Streams global available in all environments zip.js supports.